### PR TITLE
Update main

### DIFF
--- a/main
+++ b/main
@@ -4,7 +4,7 @@
 #PBS -V
 
 if [ $ENV == "IUHPC" ]; then
-   module load fsl
+   module load fsl/5.0.11
 fi
 
 rm -f t1.nii.gz


### PR DESCRIPTION
fsl default on IU hpc is now fsl 6.0.0, which requires python3.6.

switch it back to fsl 5.0.11